### PR TITLE
[4] Revise Polygon clip testing condition

### DIFF
--- a/src/calculate_volume.py
+++ b/src/calculate_volume.py
@@ -7,7 +7,7 @@ from scipy.integrate import simps
 
 import clip as c
 
-def calculate_volume(tiff, geom):
+def calculate_volume(tiff, geom, clip_save_name='', is_clip_saved_in_png=True):
     '''
     Calculate volume using GeoTiff and ShapeFile
     '''
@@ -16,7 +16,7 @@ def calculate_volume(tiff, geom):
     y_gap = abs(tiff_gt[5])
     nodata= tiff.GetRasterBand(1).GetNoDataValue()
 
-    clipped, boundary = c.clip(tiff_gt, tiff.ReadAsArray(), geom, nodata)
+    clipped, boundary = c.clip(tiff_gt, tiff.ReadAsArray(), geom, nodata, clip_save_name, is_clip_saved_in_png)
 
     # pylint: disable=len-as-condition
     if len(clipped) == 0:

--- a/src/main.py
+++ b/src/main.py
@@ -2,6 +2,7 @@
 Main entry point
 '''
 import sys
+import hashlib
 
 # pylint: disable=locally-disabled
 from osgeo import gdal, ogr # pylint: disable=import-error
@@ -15,7 +16,7 @@ def main(argv):
     `wkt_string` is a WKT format string (which describes shape of area for integration)
     This prints result as `volume: {result vaule}` format.
     '''
-    tiff_path = 'example/sample00.tif'
+    tiff_path = '../example/sample00.tif'
     # shape_path = 'example/sample00.shp'
     wkt_string = 'POLYGON ((297854.531508583 4162781.09825457,297903.046025991 4162786.45581586,297904.401298411 4162773.53837561,297884.474558611 4162770.99723982,297884.813376716 4162767.6302349,297877.444082933 4162766.95259869,297877.041736433 4162770.29842748,297855.886781003 4162768.24434272,297854.531508583 4162781.09825457))' # pylint: disable=line-too-long
 
@@ -33,7 +34,10 @@ def main(argv):
     # print(geom.ExportToWkt())
     geom = ogr.CreateGeometryFromWkt(wkt_string)
 
-    print('{ "cut": %f, "fill": %f,"volume": %f }' % calculate_volume(tiff, geom))
+    m = hashlib.md5(wkt_string.encode())
+    file_name = tiff_path[:(tiff_path.rfind('/') + 1)] + m.hexdigest()
+
+    print('{ "cut": %f, "fill": %f,"volume": %f }' % calculate_volume(tiff, geom, file_name))
 
 if __name__ == '__main__':
     main(sys.argv)


### PR DESCRIPTION
## Description
This PR revise the clip testing condition by a function added in `extent_utils.py` to solve cutting issue described in issue #4.
Along the way, few parameters added to allow (or not) the clipped polygons saved as PNG/TIFF to the same directory of the DSM files for testing. The clips will be saved in default.

Polygon:
![fireshot capture 55 - angelswing - https___dev ondronemap com_project_118_content](https://user-images.githubusercontent.com/5140297/44197798-a6b8a180-a17a-11e8-9a5e-0954b566f8bc.png)

Current:
![clipped-image-lake](https://user-images.githubusercontent.com/5140297/44197805-aae4bf00-a17a-11e8-85b4-0e046a406f0b.png)

Result after this PR:
![clipped-image-1140-lake](https://user-images.githubusercontent.com/5140297/44197664-3d389300-a17a-11e8-8ee3-80133f522570.png)

Resolves #4  
