### PR TITLE
Reproject the WKT geometry

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -5,9 +5,10 @@ import sys
 import hashlib
 
 # pylint: disable=locally-disabled
-from osgeo import gdal, ogr # pylint: disable=import-error
+from osgeo import gdal # pylint: disable=import-error
 
 from calculate_volume import calculate_volume
+from wkt_geom_utils import make_wkt_geom
 
 def main(argv):
     '''
@@ -33,7 +34,7 @@ def main(argv):
     # geom = feat.GetGeometryRef()
     # print(geom.ExportToWkt())
     # print("Projection is {}".format(tiff.GetProjection()))
-    geom = ogr.CreateGeometryFromWkt(wkt_string)
+    geom = make_wkt_geom(tiff, wkt_string)
 
     m = hashlib.md5(wkt_string.encode())
     file_name = tiff_path[:(tiff_path.rfind('/') + 1)] + m.hexdigest()

--- a/src/wkt_geom_utils.py
+++ b/src/wkt_geom_utils.py
@@ -1,0 +1,21 @@
+from osgeo import ogr, osr  # pylint: disable=import-error
+
+def make_wkt_geom(dsm_gdal_dataset, wkt_string, wkt_proj = 3857):
+    '''
+    Detect DSM GeoTiff projection system and compare with wkt_proj.
+    If they are in same projection system, do nothing.
+    Else, convert the WKT to the same projection system with the DSM GeoTiff
+    '''
+    source = osr.SpatialReference()
+    source.ImportFromEPSG(wkt_proj)
+
+    target = osr.SpatialReference()
+    target.ImportFromWkt(dsm_gdal_dataset.GetProjection())
+
+    if source.IsSame(target):
+        return ogr.CreateGeometryFromWkt(wkt_string)
+
+    transform = osr.CoordinateTransformation(source, target)
+    wkt_polygon_geom = ogr.CreateGeometryFromWkt(wkt_string)
+    wkt_polygon_geom.Transform(transform)
+    return wkt_polygon_geom


### PR DESCRIPTION
## Description
Current program requires both WKT and DSM GeoTiff to be in same projection system.
With this PR, the WKT (in default is EPSG:3857) will be re-projected to the projection system of the DSM GeoTiff if they are different.

Resolves #8 